### PR TITLE
Switch to minted for syntax highlighting and listings. Fixes issue #15.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 pdf:
-	pdflatex main.tex
+	pdflatex -shell-escape main.tex
 	bibtex main.aux
-	pdflatex main.tex
-	pdflatex main.tex
+	pdflatex -shell-escape main.tex
+	pdflatex -shell-escape main.tex
 clean:
 	(rm -rf *.ps *.log *.dvi *.aux *.*% *.lof *.lop *.lot *.toc *.idx *.ilg *.ind *.bbl *.blg *.cpt *.out)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ LaTeX:
 
 - hyperref
 - cprotect
-- float
+- minted
 - todonotes
 
 The included `f1000_styles.sty` requires these packages: authblk, babel,

--- a/main.tex
+++ b/main.tex
@@ -20,11 +20,8 @@
 % Using this to allow for \verb++ declarations in captions.
 \usepackage{cprotect}
 
-% For code floats.
-\usepackage{float}
-
-\newfloat{listing}{thp}{lop}
-\floatname{listing}{Listing}
+% Superb syntax highlighting.
+\usepackage{minted}
 
 % TODO temporary
 \usepackage{todonotes}
@@ -517,7 +514,7 @@ increase his angular velocity by bringing in his arms? The commands in Listing
 \ref{lis:ice-skate-code} perform this calculation.
 
 \begin{listing*}
-  \begin{verbatim}
+  \begin{minted}[gobble=4]{pycon}
     >>> import yeadon
     >>> pi = 3.14159
     >>> # Load a prepared measurements file.
@@ -533,7 +530,7 @@ increase his angular velocity by bringing in his arms? The commands in Listing
     >>> # Print the updated moment inertia about the global Z axis.
     >>> print('Arms out: {:.2f} kg-m^2'.format(h.inertia[2, 2]))
     Arms out: 1.58 kg-m^2
-  \end{verbatim}
+  \end{minted}
   \caption{Python interpreter session showing how one could compute the spin
     moment of inertia of an ice skater in two configurations.}
   \label{lis:ice-skate-code}
@@ -548,14 +545,14 @@ complex configurations. We can also obtain the mass and center of mass location
 of the whole human with the code presented in Listing \ref{lis:mass-com-code}.
 
 \begin{listing*}
-  \begin{verbatim}
+  \begin{minted}[gobble=4]{pycon}
     >>> h.mass
     58.200488588422544
     >>> h.center_of_mass
     array([[ -9.53791842e-19],
            [  0.00000000e+00],
            [  3.77172308e-02]])
-  \end{verbatim}
+  \end{minted}
   \caption{Python interpreter session demonstrating accessing the attributes
     for mass and center of mass.}
   \label{lis:mass-com-code}
@@ -580,7 +577,7 @@ densities so that \verb+h.mass+ is the same as our experimentally measured
 mass; see Listing \ref{lis:mass-scale-code}:
 
 \begin{listing*}
-  \begin{verbatim}
+  \begin{minted}[gobble=4]{pycon}
     >>> # Print the mass of the left leg.
     >>> h.K1.mass
     8.5047753220376521
@@ -592,7 +589,7 @@ mass; see Listing \ref{lis:mass-scale-code}:
     >>> # A slight increase in the segment mass can be seen.
     >>> h.K1.mass
     8.767736005291324
-  \end{verbatim}
+  \end{minted}
   \caption{Python interpreter session which demonstrates segment density
     scaling.}
   \label{lis:mass-scale-code}
@@ -604,7 +601,7 @@ location, and inertia tensor of the entire right arm via the code in Listing
 \ref{lis:combine-inertia-code}.
 
 \begin{listing*}
-  \begin{verbatim}
+  \begin{minted}[gobble=4]{pycon}
     >>> # Generate the mass, center of mass, and inertia tensor for the right arm.
     >>> h.combine_inertia(['B1', 'B2'])
     Combining segments/solids ['B1', 'B2'].
@@ -615,10 +612,10 @@ location, and inertia tensor of the entire right arm via the code in Listing
      matrix([[ 0.09098096,  0.        ,  0.        ],
              [ 0.        ,  0.09110269,  0.        ],
              [ 0.        ,  0.        ,  0.00194811]]))
-    \end{verbatim}
-    \caption{Python interpreter sessions which demonstrates collecting inertial
-      properties of multiple segments.}
-    \label{lis:combine-inertia-code}
+  \end{minted}
+  \caption{Python interpreter sessions which demonstrates collecting inertial
+    properties of multiple segments.}
+  \label{lis:combine-inertia-code}
 \end{listing*}
 
 All of the methods have rich docstrings accessible via the Python \verb+help()+
@@ -626,7 +623,7 @@ function. For example the previous method's docstring shows the three returned
 values in Listing \ref{lis:docstring}.
 
 \begin{listing*}
-  \begin{verbatim}
+  \begin{minted}[gobble=4]{pycon}
     >>> help(h.combine_inertia)
     Returns the inertia properties of a combination of solids
     and/or segments of the human, using the fixed human frame (or the
@@ -657,7 +654,7 @@ values in Listing \ref{lis:docstring}.
         expressed in the global frame .
     combined_inertia : np.matrix (3,3)
         Inertia tensor about the combined_COM, expressed in the global frame.
-  \end{verbatim}
+  \end{minted}
   \cprotect\caption{An example docstring for a method in the \verb+Human+
     class.}
   \label{lis:docstring}

--- a/main.tex
+++ b/main.tex
@@ -514,22 +514,22 @@ increase his angular velocity by bringing in his arms? The commands in Listing
 \ref{lis:ice-skate-code} perform this calculation.
 
 \begin{listing*}
-  \begin{minted}[gobble=4]{pycon}
-    >>> import yeadon
-    >>> pi = 3.14159
-    >>> # Load a prepared measurements file.
-    >>> h = yeadon.Human('male1.txt')
-    >>> # Create a 3D rendering of the model.
-    >>> h.draw()
-    >>> # Print the moment inertia about the global Z axis.
-    >>> print('Arms down: {:.2f} kg-m^2'.format(h.inertia[2, 2])
-    Arms down: 0.55 kg-m^2
-    >>> # Set the configuration of the shoulder angle.
-    >>> h.set_CFG('CA1adduction', -0.5 * pi)
-    >>> h.set_CFG('CB1abduction', 0.5 * pi)
-    >>> # Print the updated moment inertia about the global Z axis.
-    >>> print('Arms out: {:.2f} kg-m^2'.format(h.inertia[2, 2]))
-    Arms out: 1.58 kg-m^2
+  \begin{minted}{pycon}
+>>> import yeadon
+>>> pi = 3.14159
+>>> # Load a prepared measurements file.
+>>> h = yeadon.Human('male1.txt')
+>>> # Create a 3D rendering of the model.
+>>> h.draw()
+>>> # Print the moment inertia about the global Z axis.
+>>> print('Arms down: {:.2f} kg-m^2'.format(h.inertia[2, 2])
+Arms down: 0.55 kg-m^2
+>>> # Set the configuration of the shoulder angle.
+>>> h.set_CFG('CA1adduction', -0.5 * pi)
+>>> h.set_CFG('CB1abduction', 0.5 * pi)
+>>> # Print the updated moment inertia about the global Z axis.
+>>> print('Arms out: {:.2f} kg-m^2'.format(h.inertia[2, 2]))
+Arms out: 1.58 kg-m^2
   \end{minted}
   \caption{Python interpreter session showing how one could compute the spin
     moment of inertia of an ice skater in two configurations.}
@@ -545,13 +545,13 @@ complex configurations. We can also obtain the mass and center of mass location
 of the whole human with the code presented in Listing \ref{lis:mass-com-code}.
 
 \begin{listing*}
-  \begin{minted}[gobble=4]{pycon}
-    >>> h.mass
-    58.200488588422544
-    >>> h.center_of_mass
-    array([[ -9.53791842e-19],
-           [  0.00000000e+00],
-           [  3.77172308e-02]])
+  \begin{minted}{pycon}
+>>> h.mass
+58.200488588422544
+>>> h.center_of_mass
+array([[ -9.53791842e-19],
+       [  0.00000000e+00],
+       [  3.77172308e-02]])
   \end{minted}
   \caption{Python interpreter session demonstrating accessing the attributes
     for mass and center of mass.}
@@ -577,18 +577,18 @@ densities so that \verb+h.mass+ is the same as our experimentally measured
 mass; see Listing \ref{lis:mass-scale-code}:
 
 \begin{listing*}
-  \begin{minted}[gobble=4]{pycon}
-    >>> # Print the mass of the left leg.
-    >>> h.K1.mass
-    8.5047753220376521
-    >>> # Scale the density values based on the measured mass.
-    >>> h.scale_human_by_mass(60.0)
-    >>> # The overall mass is updated.
-    >>> h.mass
-    60.0
-    >>> # A slight increase in the segment mass can be seen.
-    >>> h.K1.mass
-    8.767736005291324
+  \begin{minted}{pycon}
+>>> # Print the mass of the left leg.
+>>> h.K1.mass
+8.5047753220376521
+>>> # Scale the density values based on the measured mass.
+>>> h.scale_human_by_mass(60.0)
+>>> # The overall mass is updated.
+>>> h.mass
+60.0
+>>> # A slight increase in the segment mass can be seen.
+>>> h.K1.mass
+8.767736005291324
   \end{minted}
   \caption{Python interpreter session which demonstrates segment density
     scaling.}
@@ -601,17 +601,17 @@ location, and inertia tensor of the entire right arm via the code in Listing
 \ref{lis:combine-inertia-code}.
 
 \begin{listing*}
-  \begin{minted}[gobble=4]{pycon}
-    >>> # Generate the mass, center of mass, and inertia tensor for the right arm.
-    >>> h.combine_inertia(['B1', 'B2'])
-    Combining segments/solids ['B1', 'B2'].
-    (2.8193675676892624,
-     array([[-0.1515    ],
-            [ 0.        ],
-            [ 0.19831659]]),
-     matrix([[ 0.09098096,  0.        ,  0.        ],
-             [ 0.        ,  0.09110269,  0.        ],
-             [ 0.        ,  0.        ,  0.00194811]]))
+  \begin{minted}{pycon}
+>>> # Generate the mass, center of mass, and inertia tensor for the right arm.
+>>> h.combine_inertia(['B1', 'B2'])
+Combining segments/solids ['B1', 'B2'].
+(2.8193675676892624,
+ array([[-0.1515    ],
+        [ 0.        ],
+        [ 0.19831659]]),
+ matrix([[ 0.09098096,  0.        ,  0.        ],
+         [ 0.        ,  0.09110269,  0.        ],
+         [ 0.        ,  0.        ,  0.00194811]]))
   \end{minted}
   \caption{Python interpreter sessions which demonstrates collecting inertial
     properties of multiple segments.}
@@ -623,37 +623,37 @@ function. For example the previous method's docstring shows the three returned
 values in Listing \ref{lis:docstring}.
 
 \begin{listing*}
-  \begin{minted}[gobble=4]{pycon}
-    >>> help(h.combine_inertia)
-    Returns the inertia properties of a combination of solids
-    and/or segments of the human, using the fixed human frame (or the
-    modified fixed frame as given by the user). Be careful with inputs:
-    do not specify a solid that is part of a segment that you have also
-    specified. This method does not assign anything to any object
-    attributes (it is 'const'), it simply returns the desired quantities.
+  \begin{minted}{pycon}
+>>> help(h.combine_inertia)
+Returns the inertia properties of a combination of solids
+and/or segments of the human, using the fixed human frame (or the
+modified fixed frame as given by the user). Be careful with inputs:
+do not specify a solid that is part of a segment that you have also
+specified. This method does not assign anything to any object
+attributes (it is 'const'), it simply returns the desired quantities.
 
-    See documentation for description of the global frame.
+See documentation for description of the global frame.
 
-    Parameters
-    ----------
-    objlist : tuple
-        Tuple of strings that identify a solid or segment. The
-        strings can be any of the following:
+Parameters
+----------
+objlist : tuple
+    Tuple of strings that identify a solid or segment. The
+    strings can be any of the following:
 
-        * solids: 's0' through 's7', 'a0' through 'a6', 'b0' through 'b6',
-          'j0' through 'j8', 'k0' through 'k8'
-        * segments: 'P', 'T', 'C', 'A1', 'A2', 'B1', 'B2', 'J1', 'J2',
-          'K1', 'K2'
+    * solids: 's0' through 's7', 'a0' through 'a6', 'b0' through 'b6',
+      'j0' through 'j8', 'k0' through 'k8'
+    * segments: 'P', 'T', 'C', 'A1', 'A2', 'B1', 'B2', 'J1', 'J2',
+      'K1', 'K2'
 
-    Returns
-    -------
-    combined_mass : float
-        Sum of the masses of the input solids and/or segments.
-    combined_COM : np.array (3,1)
-        Position of the center of mass of the input solids and/or segments,
-        expressed in the global frame .
-    combined_inertia : np.matrix (3,3)
-        Inertia tensor about the combined_COM, expressed in the global frame.
+Returns
+-------
+combined_mass : float
+    Sum of the masses of the input solids and/or segments.
+combined_COM : np.array (3,1)
+    Position of the center of mass of the input solids and/or segments,
+    expressed in the global frame .
+combined_inertia : np.matrix (3,3)
+    Inertia tensor about the combined_COM, expressed in the global frame.
   \end{minted}
   \cprotect\caption{An example docstring for a method in the \verb+Human+
     class.}


### PR DESCRIPTION
For some reason using the `pycon` lexer is giving me all grey text on my machine.

http://pygments.org/docs/lexers/#pygments.lexers.python.PythonConsoleLexer

http://tex.stackexchange.com/questions/36889/using-minted-with-mixed-python-code-and-output

I'm not sure why. The `python` lexer works ok but there is funky highlights in the output of each command.